### PR TITLE
fix: address bugs and doc gaps from Feb 21 commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,9 @@ No database required - procyclingstats.com serves as the data source via API scr
 **Core Application Files:**
 - `app.py`: Main Streamlit application (UI and display logic)
 - `api_client.py`: API integration layer (data fetching and processing)
-- `team_config.py`: Team roster and race configuration
+- `races_config.py`: Multi-race configuration and roster management (primary config file)
+- `google_sheets_import.py`: Optional Google Sheets roster loader (1-hour cache TTL)
+- `team_config.py`: Legacy backwards-compatibility shim (imports from races_config.py)
 
 **Configuration & Requirements:**
 - `requirements.txt`: Python package dependencies
@@ -215,6 +217,7 @@ No database required - procyclingstats.com serves as the data source via API scr
 **Documentation:**
 - `README.md`: User-facing documentation
 - `CLAUDE.md`: This file - project guidance for Claude Code
+- `GOOGLE_SHEETS_SETUP.md`: Setup guide for managing rosters via Google Sheets
 - `MIGRATION_GUIDE.md`: Complete guide for Google Sheets → API migration
 - `GOOGLE_SHEETS_FORMAT.md`: Legacy Google Sheets data format (deprecated)
 - `BACKUP_STEPS.md`: Git backup instructions for Replit

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Streamlit web application for tracking fantasy cycling competition results acr
 - **Mobile-Optimized**: Responsive interface with horizontal race selector
 - **Auto-refresh**: 5-minute cache for real-time updates
 - **Winner Celebrations**: Special UI for completed races
+- **Google Sheets Roster Import**: Manage team rosters via a published Google Sheet without touching code
 
 ## Live Application
 
@@ -68,7 +69,7 @@ The app automatically fetches real-time race data from **procyclingstats.com**:
 - Fantasy team scores calculated by summing rider GC times
 - Automatic handling of DNF/DNS riders
 
-**Configuration**: Team rosters and race metadata are defined in `races_config.py`. See [CLAUDE.md](CLAUDE.md) for configuration details.
+**Configuration**: Team rosters and race metadata are defined in `races_config.py`. Rosters can also be managed via a published Google Sheet — see [GOOGLE_SHEETS_SETUP.md](GOOGLE_SHEETS_SETUP.md) for setup instructions. See [CLAUDE.md](CLAUDE.md) for full configuration details.
 
 ## Technology Stack
 
@@ -109,6 +110,7 @@ The app can also be deployed on:
 ## Project Documentation
 
 - [CLAUDE.md](CLAUDE.md) - Project overview and architecture
+- [GOOGLE_SHEETS_SETUP.md](GOOGLE_SHEETS_SETUP.md) - Guide for managing rosters via Google Sheets
 - [MULTI_RACE_IMPLEMENTATION_PLAN.md](MULTI_RACE_IMPLEMENTATION_PLAN.md) - Multi-race feature implementation guide
 - [MIGRATION_SUMMARY.md](MIGRATION_SUMMARY.md) - Google Sheets → procyclingstats API migration details
 - [races_config.py](races_config.py) - Multi-race configuration file

--- a/app.py
+++ b/app.py
@@ -1375,7 +1375,7 @@ def main():
 
     if fantasy_data is None:
         st.error("Unable to load standings data. Please check the API connection or ensure race data is available.")
-        st.info("💡 Make sure team rosters are configured in team_config.py and the race has started.")
+        st.info("💡 Make sure team rosters are configured in races_config.py (or Google Sheet) and the race has started.")
         return
 
     sorted_participants = fantasy_data['standings']
@@ -1536,7 +1536,7 @@ def main():
         if rider_details:
             create_riders_display(rider_details)
         else:
-            st.error("Unable to load rider roster data. Please check the team configuration in team_config.py")
+            st.error("Unable to load rider roster data. Please check the team configuration in races_config.py")
 
 if __name__ == "__main__":
     main()

--- a/google_sheets_import.py
+++ b/google_sheets_import.py
@@ -33,10 +33,7 @@ def load_rosters_from_sheet(sheet_url):
     """
     try:
         # Convert Google Sheets URL to CSV export URL
-        if '/edit' in sheet_url:
-            sheet_id = sheet_url.split('/d/')[1].split('/')[0]
-        else:
-            sheet_id = sheet_url.split('/d/')[1].split('/')[0]
+        sheet_id = sheet_url.split('/d/')[1].split('/')[0]
         
         csv_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&gid=0"
         
@@ -63,16 +60,18 @@ def load_rosters_from_sheet(sheet_url):
             
             for _, row in race_df.iterrows():
                 participant = row['Participant']
-                
+
                 # Skip empty participants
                 if pd.isna(participant):
                     continue
-                
+
+                participant = str(participant).strip()
+
                 # Collect all rider columns (Rider1, Rider2, Rider3, etc.)
                 riders = []
                 for col in df.columns:
-                    if col.startswith('Rider') and pd.notna(row[col]) and row[col].strip():
-                        riders.append(row[col].strip())
+                    if col.startswith('Rider') and pd.notna(row[col]) and str(row[col]).strip():
+                        riders.append(str(row[col]).strip())
                 
                 rosters[participant] = riders
             


### PR DESCRIPTION
- Remove dead if/else branches in URL parsing (both did the same thing)
- Strip whitespace from participant names, not just column names and rider values
- Cast rider cell values to str before .strip() to avoid AttributeError on numeric cells
- Update stale error messages in app.py that pointed to team_config.py (now races_config.py)
- Add Google Sheets roster import feature and GOOGLE_SHEETS_SETUP.md to README
- Add google_sheets_import.py and GOOGLE_SHEETS_SETUP.md to CLAUDE.md file structure
- Clarify races_config.py vs team_config.py roles in CLAUDE.md

Note: api_client.py still uses hardcoded TEAM_ROSTERS from team_config.py for scoring calculations (fetch_fantasy_standings, fetch_stage_by_stage_data). The new Google Sheets integration in get_team_rosters() only affects the Team Riders display tab in app.py. Scoring will need a separate fix to pass race_id/rosters into api_client functions.

https://claude.ai/code/session_0139fddnNsHazCZqFFTfZbJT